### PR TITLE
Added parenesis for REGEX REPLACE command to fix this error:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,9 @@ string(REPLACE "-O3" "-O2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 add_definitions(-DOSTYPE="${CMAKE_SYSTEM_NAME}")
 
 # Architecture string
-string(REGEX REPLACE "amd64" "x86_64" ARCH ${CMAKE_SYSTEM_PROCESSOR})
-string(REGEX REPLACE "i.86" "i386" ARCH ${ARCH})
-string(REGEX REPLACE "^arm.*" "arm" ARCH ${ARCH})
+string(REGEX REPLACE "amd64" "x86_64" ARCH "${CMAKE_SYSTEM_PROCESSOR}")
+string(REGEX REPLACE "i.86" "i386" ARCH "${ARCH}")
+string(REGEX REPLACE "^arm.*" "arm" ARCH "${ARCH}")
 add_definitions(-DARCH="${ARCH}")
 
 # Linker Flags


### PR DESCRIPTION
CMake Error at CMakeLists.txt:25 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.