### PR TITLE
Xatrix bugfix for monsters not fighting back against parasites

### DIFF
--- a/src/g_monster.c
+++ b/src/g_monster.c
@@ -1169,7 +1169,10 @@ flymonster_start_go(edict_t *self)
 		self->yaw_speed = 10;
 	}
 
-	self->viewheight = 25;
+	if (!self->viewheight)
+	{
+		self->viewheight = 25;
+	}
 
 	monster_start_go(self);
 
@@ -1205,7 +1208,10 @@ swimmonster_start_go(edict_t *self)
 		self->yaw_speed = 10;
 	}
 
-	self->viewheight = 10;
+	if (!self->viewheight)
+	{
+		self->viewheight = 10;
+	}
 
 	monster_start_go(self);
 

--- a/src/monster/fixbot/fixbot.c
+++ b/src/monster/fixbot/fixbot.c
@@ -1614,6 +1614,7 @@ SP_monster_fixbot(edict_t *self)
 
 	self->health = 150;
 	self->mass = 150;
+	self->viewheight = 16;
 
 	self->pain = fixbot_pain;
 	self->die = fixbot_die;

--- a/src/monster/parasite/parasite.c
+++ b/src/monster/parasite/parasite.c
@@ -734,6 +734,7 @@ SP_monster_parasite(edict_t *self)
 	self->health = 175;
 	self->gib_health = -50;
 	self->mass = 250;
+	self->viewheight = 16;
 
 	self->pain = parasite_pain;
 	self->die = parasite_die;


### PR DESCRIPTION
Addresses the same issue in xatrix as in yquake2 for bug https://github.com/yquake2/yquake2/issues/440. Additionally I applied the same change to the fixbot monster since its maxs[2] is also 24 which is lower than the old viewheight of 25 and thus had the same problem as the parasite.