### PR TITLE
Makefile fix for Windows and gitignore now ignores the release folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build/
+/release/

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ endif
 ifneq (,$(findstring MINGW,$(OSTYPE)))
 OSTYPE := Windows
 endif
+
+# On Windows / MinGW $(CC) is undefined by default.
+ifeq ($(OSTYPE),Windows)
+CC := gcc
+endif
  
 # Detect the architecture
 ifeq ($(OSTYPE), Windows)
@@ -78,7 +83,7 @@ ifeq ($(OSTYPE), Darwin)
 CFLAGS := -O2 -fno-strict-aliasing -fomit-frame-pointer \
 		  -Wall -pipe -g -fwrapv -arch i386 -arch x86_64
 else
-CFLAGS := -O2 -fno-strict-aliasing -fomit-frame-pointer \
+CFLAGS := -std=gnu99 -O2 -fno-strict-aliasing -fomit-frame-pointer \
 		  -Wall -pipe -g -MMD -fwrapv
 endif
 


### PR DESCRIPTION
I found I was unable to make yquake2/xatrix on Windows and found that it was because the CC variable was undefined. I added the same check as the one in yquake2/yquake2 to fix this. Additionally I added -std=gnu99 to non-Darwin CFLAGS so that the code compiles (it was complaining about variable declaration inside loop initializer statement).

I also added the release folder to gitignore, since we obviously don't want that to be a part of the repo.