### PR TITLE
Beta-class iron maiden fixes

### DIFF
--- a/src/g_weapon.c
+++ b/src/g_weapon.c
@@ -1341,25 +1341,18 @@ heat_think(edict_t *self)
 	edict_t *target = NULL;
 	edict_t *aquire = NULL;
 	vec3_t vec;
-	int len;
-	int oldlen = 0;
+	float len;
+	float oldlen = 0;
 
 	if (!self)
 	{
 		return;
 	}
 
-	VectorClear(vec);
-
 	/* aquire new target */
 	while ((target = findradius(target, self->s.origin, 1024)) != NULL)
 	{
 		if (self->owner == target)
-		{
-			continue;
-		}
-
-		if ((!target->svflags) & SVF_MONSTER)
 		{
 			continue;
 		}
@@ -1374,12 +1367,12 @@ heat_think(edict_t *self)
 			continue;
 		}
 
-		if (!visible(self, target))
+		if (!infront(self, target))
 		{
 			continue;
 		}
 
-		if (!infront(self, target))
+		if (!visible(self, target))
 		{
 			continue;
 		}
@@ -1387,20 +1380,18 @@ heat_think(edict_t *self)
 		VectorSubtract(self->s.origin, target->s.origin, vec);
 		len = VectorLength(vec);
 
-		if ((aquire == NULL) || (len < oldlen))
+		if ((!aquire) || (len < oldlen))
 		{
 			aquire = target;
-			self->target_ent = aquire;
 			oldlen = len;
 		}
 	}
 
-	if (aquire != NULL)
+	if (aquire)
 	{
 		VectorSubtract(aquire->s.origin, self->s.origin, vec);
 		vectoangles(vec, self->s.angles);
 		VectorNormalize(vec);
-		VectorCopy(vec, self->movedir);
 		VectorScale(vec, 500, self->velocity);
 	}
 

--- a/src/monster/chick/chick.c
+++ b/src/monster/chick/chick.c
@@ -631,7 +631,7 @@ ChickRocket(edict_t *self)
 	VectorSubtract(vec, start, dir);
 	VectorNormalize(dir);
 
-	if (self->s.skinnum > 1)
+	if (!strcmp(self->classname, "monster_chick_heat"))
 	{
 		monster_fire_heat(self, start, dir, 50, 500, MZ2_CHICK_ROCKET_1);
 	}
@@ -949,5 +949,10 @@ SP_monster_chick_heat(edict_t *self)
 	}
 
 	SP_monster_chick(self);
-	self->s.skinnum = 3;
+
+	/* have to check this since the regular spawn function can free the entity */
+	if (self->inuse)
+	{
+		self->s.skinnum = 3;
+	}
 }


### PR DESCRIPTION
This pull request fixes bug https://github.com/yquake2/xatrix/issues/20. The firing function now uses the classname to determine whether it's the normal iron maiden or the beta-class variant.

I also happened to notice that in the spawn function of the beta-class iron maiden, s.skinnum is set to 3 without first checking whether the entity is still in use. This is bad because the regular spawn function frees the entity in deathmatch, so the next time this entity is allocated by G_Spawn it is "dirty" since only G_FreeEdict resets the memory of the entity, and thus could potentially lead to strange hard-to-find bugs.

While debugging the homing rockets I took a look at heat_think() in g_weapons and, while it wasn't the source of the bug, I made some improvements there as the code looked fairly last-minute and problematic. Namely removed useless statements (what exactly was "(!target->svflags) & SVF_MONSTER" doing...?), moved the expensive visible() trace to come after the much cheaper infront(), and made the code style consistent with the rest of the code base.

Tested these changes in map refinery and everything is working perfectly as far as I can tell. The rockets home as they should and the beta-class iron maidens keep their homing rockets until they die.