### PR TITLE
Fixed fixbot bot_goal leak

### DIFF
--- a/src/monster/fixbot/fixbot.c
+++ b/src/monster/fixbot/fixbot.c
@@ -149,6 +149,42 @@ fixbot_search(edict_t *self)
 }
 
 void
+bot_goal_think(edict_t *self)
+{
+	if (!self)
+	{
+		return;
+	}
+
+	/* clean up the bot_goal if the fixbot loses it (to avoid entity leaks) */
+	if (!self->owner || !self->owner->inuse || self->owner->goalentity != self)
+	{
+		G_FreeEdict(self);
+	}
+	else
+	{
+		self->nextthink = level.time + FRAMETIME;
+	}
+}
+
+static edict_t *
+make_bot_goal(edict_t *self)
+{
+	edict_t *ent = G_Spawn();
+
+	ent->classname = "bot_goal";
+	ent->solid = SOLID_BBOX;
+	ent->owner = self;
+
+	ent->think = bot_goal_think;
+	ent->nextthink = level.time + FRAMETIME;
+
+	gi.linkentity(ent);
+
+	return ent;
+}
+
+void
 landing_goal(edict_t *self)
 {
 	trace_t tr;
@@ -161,11 +197,7 @@ landing_goal(edict_t *self)
 		return;
 	}
 
-	ent = G_Spawn();
-	ent->classname = "bot_goal";
-	ent->solid = SOLID_BBOX;
-	ent->owner = self;
-	gi.linkentity(ent);
+	ent = make_bot_goal(self);
 
 	VectorSet(ent->mins, -32, -32, -24);
 	VectorSet(ent->maxs, 32, 32, 24);
@@ -196,11 +228,7 @@ takeoff_goal(edict_t *self)
 		return;
 	}
 
-	ent = G_Spawn();
-	ent->classname = "bot_goal";
-	ent->solid = SOLID_BBOX;
-	ent->owner = self;
-	gi.linkentity(ent);
+	ent = make_bot_goal(self);
 
 	VectorSet(ent->mins, -32, -32, -24);
 	VectorSet(ent->maxs, 32, 32, 24);
@@ -283,11 +311,7 @@ roam_goal(edict_t *self)
 	whichvec[1] = 0;
 	whichvec[2] = 0;
 
-	ent = G_Spawn();
-	ent->classname = "bot_goal";
-	ent->solid = SOLID_BBOX;
-	ent->owner = self;
-	gi.linkentity(ent);
+	ent = make_bot_goal(self);
 
 	oldlen = 0;
 

--- a/src/savegame/tables/gamefunc_decs.h
+++ b/src/savegame/tables/gamefunc_decs.h
@@ -570,6 +570,7 @@ extern void flipper_run ( edict_t * self ) ;
 extern void flipper_run_loop ( edict_t * self ) ;
 extern void flipper_stand ( edict_t * self ) ;
 extern void SP_monster_fixbot ( edict_t * self ) ;
+extern void bot_goal_think ( edict_t *self ) ;
 extern void fixbot_die ( edict_t * self , edict_t * inflictor , edict_t * attacker , int damage , vec3_t point ) ;
 extern void fixbot_dead ( edict_t * self ) ;
 extern void fixbot_pain ( edict_t * self , edict_t * other , float kick , int damage ) ;

--- a/src/savegame/tables/gamefunc_list.h
+++ b/src/savegame/tables/gamefunc_list.h
@@ -570,6 +570,7 @@
 {"flipper_run_loop", (byte *)flipper_run_loop},
 {"flipper_stand", (byte *)flipper_stand},
 {"SP_monster_fixbot", (byte *)SP_monster_fixbot},
+{"bot_goal_think", (byte *)bot_goal_think},
 {"fixbot_die", (byte *)fixbot_die},
 {"fixbot_dead", (byte *)fixbot_dead},
 {"fixbot_pain", (byte *)fixbot_pain},


### PR DESCRIPTION
This pull request fixes bug https://github.com/yquake2/xatrix/issues/23.

I fixed it by giving bot_goals a think function. It has the sole purpose of checking the status of its owner. If the owner is gone or has changed its goalentity, the bot_goal will free itself. I went with this solution because making the fixbot or T_Damage do the cleanup is error prone and there could be other edge cases that slip by, with this approach it is guaranteed that no bot_goals will leak.