### PR TITLE
maxvelocity correctly enforced

### DIFF
--- a/src/g_phys.c
+++ b/src/g_phys.c
@@ -70,24 +70,15 @@ SV_TestEntityPosition(edict_t *ent)
 void
 SV_CheckVelocity(edict_t *ent)
 {
-	int i;
-
   	if (!ent)
 	{
 		return;
 	}
 
-	/* bound velocity */
-	for (i = 0; i < 3; i++)
+	if (VectorLength(ent->velocity) > sv_maxvelocity->value)
 	{
-		if (ent->velocity[i] > sv_maxvelocity->value)
-		{
-			ent->velocity[i] = sv_maxvelocity->value;
-		}
-		else if (ent->velocity[i] < -sv_maxvelocity->value)
-		{
-			ent->velocity[i] = -sv_maxvelocity->value;
-		}
+		VectorNormalize(ent->velocity);
+		VectorScale(ent->velocity, sv_maxvelocity->value, ent->velocity);
 	}
 }
 


### PR DESCRIPTION
I noticed that you had already fixed SV_CheckVelocity in yquake2 but not rogue or xatrix, so I went ahead and copied the new implementation over to them.