### PR TITLE
Gekk AI fixes

### DIFF
--- a/src/g_combat.c
+++ b/src/g_combat.c
@@ -677,7 +677,7 @@ T_Damage(edict_t *targ, edict_t *inflictor, edict_t *attacker, vec3_t dir,
 	{
 		M_ReactToDamage(targ, attacker);
 
-		if (!(targ->monsterinfo.aiflags & AI_DUCKED) && (take))
+		if (!(targ->monsterinfo.aiflags & (AI_DUCKED|AI_IGNORE_PAIN)) && (take))
 		{
 			targ->pain(targ, attacker, knockback, take);
 

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -128,6 +128,7 @@ typedef enum
 #define AI_COMBAT_POINT 0x00001000
 #define AI_MEDIC 0x00002000
 #define AI_RESURRECTING 0x00004000
+#define AI_IGNORE_PAIN 0x00008000
 
 /* monster attack state */
 #define AS_STRAIGHT 1

--- a/src/monster/gekk/gekk.c
+++ b/src/monster/gekk/gekk.c
@@ -8,6 +8,8 @@
 #include "../../header/local.h"
 #include "gekk.h"
 
+#define SPAWNFLAG_CHANT	8
+
 static int sound_swing;
 static int sound_hit;
 static int sound_hit2;
@@ -25,7 +27,6 @@ static int sound_chanthigh;
 
 mmove_t gekk_move_attack1;
 mmove_t gekk_move_attack2;
-mmove_t gekk_move_chant;
 mmove_t gekk_move_swim_start;
 mmove_t gekk_move_swim_loop;
 mmove_t gekk_move_spit;
@@ -224,7 +225,7 @@ gekk_search(edict_t *self)
 		return;
 	}
 
-	if (self->spawnflags & 8)
+	if (self->spawnflags & SPAWNFLAG_CHANT)
 	{
 		r = random();
 
@@ -297,7 +298,7 @@ ai_stand2(edict_t *self, float dist)
 		return;
 	}
 
-	if (self->spawnflags & 8)
+	if (self->spawnflags & SPAWNFLAG_CHANT)
 	{
 		ai_move(self, dist);
 
@@ -314,6 +315,10 @@ ai_stand2(edict_t *self, float dist)
 				self->monsterinfo.idle_time = level.time + random() * 15;
 			}
 		}
+	}
+	else if (self->enemy)
+	{
+		ai_move(self, dist);
 	}
 	else
 	{
@@ -499,17 +504,6 @@ gekk_stand(edict_t *self)
 }
 
 void
-gekk_chant(edict_t *self)
-{
-  	if (!self)
-	{
-		return;
-	}
-
-	self->monsterinfo.currentmove = &gekk_move_chant;
-}
-
-void
 gekk_idle_loop(edict_t *self)
 {
   	if (!self)
@@ -573,51 +567,6 @@ mmove_t gekk_move_idle2 = {
    	FRAME_idle_32,
    	gekk_frames_idle,
    	gekk_face
-};
-
-mframe_t gekk_frames_idle2[] = {
-	{ai_move, 0, gekk_search},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-	{ai_move, 0, NULL},
-
-	{ai_move, 0, NULL},
-	{ai_move, 0, gekk_idle_loop}
-};
-
-mmove_t gekk_move_chant = {
-	FRAME_idle_01,
-   	FRAME_idle_32,
-   	gekk_frames_idle2,
-   	gekk_chant
 };
 
 void
@@ -1415,9 +1364,9 @@ gekk_pain(edict_t *self, edict_t *other /* unused */,
 		return;
 	}
 
-	if (self->spawnflags & 8)
+	if (self->spawnflags & SPAWNFLAG_CHANT)
 	{
-		self->spawnflags &= ~8;
+		self->spawnflags &= ~SPAWNFLAG_CHANT;
 		return;
 	}
 
@@ -2018,11 +1967,6 @@ SP_monster_gekk(edict_t *self)
 
 	self->monsterinfo.scale = MODEL_SCALE;
 	walkmonster_start(self);
-
-	if (self->spawnflags & 8)
-	{
-		self->monsterinfo.currentmove = &gekk_move_chant;
-	}
 }
 
 void

--- a/src/monster/gekk/gekk.c
+++ b/src/monster/gekk/gekk.c
@@ -38,7 +38,6 @@ void gekk_swim(edict_t *self);
 void gekk_jump_takeoff(edict_t *self);
 void gekk_jump_takeoff2(edict_t *self);
 void gekk_check_landing(edict_t *self);
-void gekk_check_landing2(edict_t *self);
 void gekk_stop_skid(edict_t *self);
 void water_to_land(edict_t *self);
 void land_to_water(edict_t *self);
@@ -1112,7 +1111,7 @@ void
 gekk_jump_touch(edict_t *self, edict_t *other, cplane_t *plane /* unsued */,
 		csurface_t *surf /* unused */)
 {
-  	if (!self || !other)
+  	if (!self)
 	{
 		return;
 	}
@@ -1123,7 +1122,7 @@ gekk_jump_touch(edict_t *self, edict_t *other, cplane_t *plane /* unsued */,
 		return;
 	}
 
-	if (other->takedamage)
+	if (other && other->takedamage)
 	{
 		if (VectorLength(self->velocity) > 200)
 		{
@@ -1145,12 +1144,14 @@ gekk_jump_touch(edict_t *self, edict_t *other, cplane_t *plane /* unsued */,
 		if (self->groundentity)
 		{
 			self->monsterinfo.nextframe = FRAME_leapatk_11;
+			self->monsterinfo.aiflags &= ~AI_IGNORE_PAIN;
 			self->touch = NULL;
 		}
 
 		return;
 	}
 
+	self->monsterinfo.aiflags &= ~AI_IGNORE_PAIN;
 	self->touch = NULL;
 }
 
@@ -1181,7 +1182,7 @@ gekk_jump_takeoff(edict_t *self)
 	}
 
 	self->groundentity = NULL;
-	self->monsterinfo.aiflags |= AI_DUCKED;
+	self->monsterinfo.aiflags |= AI_IGNORE_PAIN;
 	self->monsterinfo.attack_finished = level.time + 3;
 	self->touch = gekk_jump_touch;
 }
@@ -1212,7 +1213,7 @@ gekk_jump_takeoff2(edict_t *self)
 	}
 
 	self->groundentity = NULL;
-	self->monsterinfo.aiflags |= AI_DUCKED;
+	self->monsterinfo.aiflags |= AI_IGNORE_PAIN;
 	self->monsterinfo.attack_finished = level.time + 3;
 	self->touch = gekk_jump_touch;
 }
@@ -1243,7 +1244,7 @@ gekk_check_landing(edict_t *self)
 	{
 		gi.sound(self, CHAN_WEAPON, sound_thud, 1, ATTN_NORM, 0);
 		self->monsterinfo.attack_finished = 0;
-		self->monsterinfo.aiflags &= ~AI_DUCKED;
+		self->monsterinfo.aiflags &= ~AI_IGNORE_PAIN;
 
 		VectorClear(self->velocity);
 

--- a/src/savegame/tables/gamefunc_decs.h
+++ b/src/savegame/tables/gamefunc_decs.h
@@ -506,7 +506,6 @@ extern void gekk_run_start ( edict_t * self ) ;
 extern void gekk_walk ( edict_t * self ) ;
 extern void gekk_idle ( edict_t * self ) ;
 extern void gekk_idle_loop ( edict_t * self ) ;
-extern void gekk_chant ( edict_t * self ) ;
 extern void gekk_stand ( edict_t * self ) ;
 extern void gekk_swim ( edict_t * self ) ;
 extern void gekk_swim_loop ( edict_t * self ) ;

--- a/src/savegame/tables/gamefunc_list.h
+++ b/src/savegame/tables/gamefunc_list.h
@@ -506,7 +506,6 @@
 {"gekk_walk", (byte *)gekk_walk},
 {"gekk_idle", (byte *)gekk_idle},
 {"gekk_idle_loop", (byte *)gekk_idle_loop},
-{"gekk_chant", (byte *)gekk_chant},
 {"gekk_stand", (byte *)gekk_stand},
 {"gekk_swim", (byte *)gekk_swim},
 {"gekk_swim_loop", (byte *)gekk_swim_loop},

--- a/src/savegame/tables/gamemmove_decs.h
+++ b/src/savegame/tables/gamemmove_decs.h
@@ -214,7 +214,6 @@ extern mmove_t gekk_move_spit ;
 extern mmove_t gekk_move_run_start ;
 extern mmove_t gekk_move_run ;
 extern mmove_t gekk_move_walk ;
-extern mmove_t gekk_move_chant ;
 extern mmove_t gekk_move_idle2 ;
 extern mmove_t gekk_move_idle ;
 extern mmove_t gekk_move_swim_start ;

--- a/src/savegame/tables/gamemmove_list.h
+++ b/src/savegame/tables/gamemmove_list.h
@@ -214,7 +214,6 @@
 {"gekk_move_run_start", &gekk_move_run_start},
 {"gekk_move_run", &gekk_move_run},
 {"gekk_move_walk", &gekk_move_walk},
-{"gekk_move_chant", &gekk_move_chant},
 {"gekk_move_idle2", &gekk_move_idle2},
 {"gekk_move_idle", &gekk_move_idle},
 {"gekk_move_swim_start", &gekk_move_swim_start},


### PR DESCRIPTION
This pull request addresses bugs https://github.com/yquake2/xatrix/issues/28 and https://github.com/yquake2/xatrix/issues/29.

The first bug was fixed by making angry gekks call ai_move rather than ai_stand inside ai_stand2. ai_move is a lot more appropriate for this situation sine ai_stand is intended for monsters who are either stand ground or idle/not angry.

The second bug was fixed by introducing a new AI flag, AI_IGNORE_PAIN, and clear it in all possible outcomes of the jump. I added this new flag so that it doesn't interfere with AI_DUCKED since their purposes are different.

Finally, I eliminated the unused gekk_move_chant. Even though this move is set in the spawn function for chanting gekks, monster_start_go() will override it, so it never actually gets played. Chanting gekks actually do their chanting in the idle move. I did this to simplify the code a bit as it was pretty confusing and made debugging the above issues harder.