### PR TITLE
Code issues reported by PVS addressed

### DIFF
--- a/src/g_ai.c
+++ b/src/g_ai.c
@@ -770,10 +770,6 @@ M_CheckAttack(edict_t *self)
 	{
 		chance = 0.4;
 	}
-	else if (enemy_range == RANGE_MELEE)
-	{
-		chance = 0.2;
-	}
 	else if (enemy_range == RANGE_NEAR)
 	{
 		chance = 0.1;
@@ -1277,9 +1273,5 @@ ai_run(edict_t *self, float dist)
 
 	G_FreeEdict(tempgoal);
 
-	if (self)
-	{
-		self->goalentity = save;
-	}
+	self->goalentity = save;
 }
-

--- a/src/g_cmds.c
+++ b/src/g_cmds.c
@@ -1215,7 +1215,7 @@ Cmd_Say_f(edict_t *ent, qboolean team, qboolean arg0)
 void
 Cmd_PlayerList_f(edict_t *ent)
 {
-	int i;
+	int i, text_len;
 	char st[80];
 	char text[1400];
 	edict_t *e2;
@@ -1226,7 +1226,7 @@ Cmd_PlayerList_f(edict_t *ent)
 	}
 
 	/* connect time, ping, score, name */
-	*text = 0;
+	*text = '\0';
 
 	for (i = 0, e2 = g_edicts + 1; i < maxclients->value; i++, e2++)
 	{
@@ -1242,9 +1242,11 @@ Cmd_PlayerList_f(edict_t *ent)
 				e2->client->pers.netname,
 				e2->client->resp.spectator ? " (spectator)" : "");
 
-		if (strlen(text) + strlen(st) > sizeof(text) - 50)
+		text_len = strlen(text);
+
+		if ((text_len + strlen(st)) > (sizeof(text) - 50))
 		{
-			sprintf(text + strlen(text), "And more...\n");
+			snprintf(text + text_len, sizeof(text) - text_len, "And more...\n");
 			gi.cprintf(ent, PRINT_HIGH, "%s", text);
 			return;
 		}

--- a/src/g_combat.c
+++ b/src/g_combat.c
@@ -127,7 +127,7 @@ Killed(edict_t *targ, edict_t *inflictor, edict_t *attacker,
 			}
 
 			/* medics won't heal monsters that they kill themselves */
-			if (attacker && attacker->classname && strcmp(attacker->classname, "monster_medic") == 0)
+			if (attacker->classname && strcmp(attacker->classname, "monster_medic") == 0)
 			{
 				targ->owner = attacker;
 			}
@@ -470,7 +470,7 @@ M_ReactToDamage(edict_t *targ, edict_t *attacker)
 		}
 	}
 	/* otherwise get mad at whoever they are mad at (help our buddy) unless it is us! */
-	else if (attacker->enemy && (attacker->enemy != targ))
+	else if (attacker->enemy)
 	{
 		if (targ->enemy && targ->enemy->client)
 		{
@@ -633,12 +633,6 @@ T_Damage(edict_t *targ, edict_t *inflictor, edict_t *attacker, vec3_t dir,
 
 	/* treat cheat/powerup savings the same as armor */
 	asave += save;
-
-	/* team damage avoidance */
-	if (!(dflags & DAMAGE_NO_PROTECTION) && false)
-	{
-		return;
-	}
 
 	/* do the damage */
 	if (take)

--- a/src/g_func.c
+++ b/src/g_func.c
@@ -540,7 +540,7 @@ plat_blocked(edict_t *self, edict_t *other)
 				vec3_origin, 100000, 1, 0, MOD_CRUSH);
 
 		/* if it's still there, nuke it */
-		if (other)
+		if (other->inuse)
 		{
 			/* Hack for entity without it's origin near the model */
 			VectorMA (other->absmin, 0.5, other->size, other->s.origin);
@@ -630,7 +630,6 @@ plat_spawn_inside_trigger(edict_t *ent)
 
 	tmin[0] = ent->mins[0] + 25;
 	tmin[1] = ent->mins[1] + 25;
-	tmin[2] = ent->mins[2];
 
 	tmax[0] = ent->maxs[0] - 25;
 	tmax[1] = ent->maxs[1] - 25;
@@ -903,10 +902,7 @@ SP_func_rotating(edict_t *ent)
 
 	ent->use = rotating_use;
 
-	if (ent->dmg)
-	{
-		ent->blocked = rotating_blocked;
-	}
+	ent->blocked = rotating_blocked;
 
 	if (ent->spawnflags & 1)
 	{
@@ -1379,9 +1375,6 @@ door_use(edict_t *self, edict_t *other /* unused */, edict_t *activator)
 
 	edict_t *ent;
 
-	if (!self)
-		return;
-
 	if (self->flags & FL_TEAMSLAVE)
 	{
 		return;
@@ -1576,7 +1569,7 @@ door_blocked(edict_t *self, edict_t *other)
 				vec3_origin, 100000, 1, 0, MOD_CRUSH);
 
 		/* if it's still there, nuke it */
-		if (other)
+		if (other->inuse)
 		{
 			/* Hack for entitiy without their origin near the model */
 			VectorMA (other->absmin, 0.5, other->size, other->s.origin);
@@ -2003,10 +1996,6 @@ SP_func_water(edict_t *self)
 			break;
 
 		case 1: /* water */
-			self->moveinfo.sound_start = gi.soundindex("world/mov_watr.wav");
-			self->moveinfo.sound_end = gi.soundindex("world/stp_watr.wav");
-			break;
-
 		case 2: /* lava */
 			self->moveinfo.sound_start = gi.soundindex("world/mov_watr.wav");
 			self->moveinfo.sound_end = gi.soundindex("world/stp_watr.wav");
@@ -2103,7 +2092,7 @@ train_blocked(edict_t *self, edict_t *other)
 				vec3_origin, 100000, 1, 0, MOD_CRUSH);
 
 		/* if it's still there, nuke it */
-		if (other)
+		if (other->inuse)
 		{
 			/* Hack for entity without an origin near the model */			
 			VectorMA (other->absmin, 0.5, other->size, other->s.origin);
@@ -2800,7 +2789,7 @@ door_secret_blocked(edict_t *self, edict_t *other)
 				vec3_origin, 100000, 1, 0, MOD_CRUSH);
 
 		/* if it's still there, nuke it */
-		if (other)
+		if (other->inuse)
 		{
 			/* Hack for entities without their origin near the model */
 			VectorMA (other->absmin, 0.5, other->size, other->s.origin);

--- a/src/g_items.c
+++ b/src/g_items.c
@@ -1379,13 +1379,13 @@ Drop_Item(edict_t *ent, gitem_t *item)
 	dropped->s.effects = item->world_model_flags;
 	dropped->s.renderfx = RF_GLOW;
 
-	if (rand() > 0.5)
+	if (random() > 0.5)
 	{
-		dropped->s.angles[1] += rand()*45;
+		dropped->s.angles[1] += random()*45;
 	}
 	else
 	{
-		dropped->s.angles[1] -= rand()*45;
+		dropped->s.angles[1] -= random()*45;
 	}
 
 	VectorSet (dropped->mins, -16, -16, -16);

--- a/src/g_misc.c
+++ b/src/g_misc.c
@@ -124,12 +124,12 @@ gib_think(edict_t *self)
 void
 gib_touch(edict_t *self, edict_t *other /* unused */, cplane_t *plane, csurface_t *surf /* unused */)
 {
-	if (!self || !plane)
+	vec3_t normal_angles, right;
+
+	if (!self)
 	{
 		return;
 	}
-
-	vec3_t normal_angles, right;
 
 	if (!self->groundentity)
 	{
@@ -1002,12 +1002,6 @@ func_object_touch(edict_t *self, edict_t *other, cplane_t *plane,
 		return;
 	}
 
-	/* only squash thing we fall on top of */
-	if (!plane)
-	{
-		return;
-	}
-
 	if (plane->normal[2] < 1.0)
 	{
 		return;
@@ -1357,7 +1351,7 @@ barrel_explode(edict_t *self)
 	ThrowDebris(self, "models/objects/debris3/tris.md2", spd, org);
 
 	/* a bunch of little chunks */
-	spd = 2 * self->dmg / 200;
+	spd = (float)(2 * self->dmg / 200);
 	org[0] = self->s.origin[0] + crandom() * self->size[0];
 	org[1] = self->s.origin[1] + crandom() * self->size[1];
 	org[2] = self->s.origin[2] + crandom() * self->size[2];

--- a/src/g_svcmds.c
+++ b/src/g_svcmds.c
@@ -111,6 +111,7 @@ StringToFilter(char *s, ipfilter_t *f)
 		s++;
 	}
 
+	/* PVS NOTE: maybe use memcpy here instead? */
 	f->mask = *(unsigned *)m;
 	f->compare = *(unsigned *)b;
 
@@ -151,6 +152,7 @@ SV_FilterPacket(char *from)
 		i++, p++;
 	}
 
+	/* PVS NOTE: maybe use memcpy instead? */
 	in = *(unsigned *)m;
 
 	for (i = 0; i < numipfilters; i++)
@@ -246,6 +248,7 @@ SVCmd_ListIP_f(void)
 
 	for (i = 0; i < numipfilters; i++)
 	{
+		/* PVS NOTE: maybe use memcpy instead? */
 		*(unsigned *)b = ipfilters[i].compare;
 		gi.cprintf(NULL, PRINT_HIGH, "%3i.%3i.%3i.%3i\n",
 				b[0], b[1], b[2], b[3]);
@@ -286,6 +289,7 @@ SVCmd_WriteIP_f(void)
 
 	for (i = 0; i < numipfilters; i++)
 	{
+		/* PVS NOTE: maybe use memcpy instead? */
 		*(unsigned *)b = ipfilters[i].compare;
 		fprintf(f, "sv addip %i.%i.%i.%i\n", b[0], b[1], b[2], b[3]);
 	}

--- a/src/g_target.c
+++ b/src/g_target.c
@@ -407,7 +407,7 @@ use_target_changelevel(edict_t *self, edict_t *other, edict_t *activator)
 	/* if multiplayer, let everyone know who hit the exit */
 	if (deathmatch->value)
 	{
-		if (activator && activator->client)
+		if (activator->client)
 		{
 			gi.bprintf(PRINT_HIGH, "%s exited the level.\n",
 					activator->client->pers.netname);
@@ -554,13 +554,13 @@ use_target_spawner(edict_t *self, edict_t *other /* unused */, edict_t *activato
 void
 SP_target_spawner(edict_t *self)
 {
-	self->use = use_target_spawner;
-	self->svflags = SVF_NOCLIENT;
-
   	if (!self)
 	{
 		return;
 	}
+
+	self->use = use_target_spawner;
+	self->svflags = SVF_NOCLIENT;
 
 	if (self->speed)
 	{

--- a/src/g_trigger.c
+++ b/src/g_trigger.c
@@ -642,14 +642,14 @@ trigger_push_active(edict_t *self)
 void
 SP_trigger_push(edict_t *self)
 {
-	InitTrigger(self);
-	windsound = gi.soundindex("misc/windfly.wav");
-	self->touch = trigger_push_touch;
-
   	if (!self)
 	{
 		return;
 	}
+
+	InitTrigger(self);
+	windsound = gi.soundindex("misc/windfly.wav");
+	self->touch = trigger_push_touch;
 
 	if (self->spawnflags & 2)
 	{

--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -321,6 +321,19 @@ vtos(vec3_t v)
 	return s;
 }
 
+void
+get_normal_vector(const cplane_t *p, vec3_t normal)
+{
+	if (p)
+	{
+		VectorCopy(p->normal, normal);
+	}
+	else
+	{
+		VectorCopy(vec3_origin, normal);
+	}
+}
+
 vec3_t VEC_UP = {0, -1, 0};
 vec3_t MOVEDIR_UP = {0, 0, 1};
 vec3_t VEC_DOWN = {0, -2, 0};

--- a/src/g_weapon.c
+++ b/src/g_weapon.c
@@ -9,6 +9,19 @@
 
 extern void SP_item_foodcube(edict_t *best);
 
+static void
+get_normal_vector(const cplane_t *p, vec3_t normal)
+{
+	if (p)
+	{
+		VectorCopy(p->normal, normal);
+	}
+	else
+	{
+		VectorCopy(vec3_origin, normal);
+	}
+}
+
 /*
  * This is a support routine used when a client is firing
  * a non-instant attack weapon.  It checks to see if a
@@ -353,6 +366,7 @@ void
 blaster_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
 {
 	int mod;
+	vec3_t normal;
 
 	if (!self || !other)
 	{
@@ -376,6 +390,8 @@ blaster_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
 		PlayerNoise(self->owner, self->s.origin, PNOISE_IMPACT);
 	}
 
+	get_normal_vector(plane, normal);
+
 	if (other->takedamage)
 	{
 		if (self->spawnflags & 1)
@@ -388,23 +404,14 @@ blaster_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
 		}
 
 		T_Damage(other, self, self->owner, self->velocity, self->s.origin,
-				plane->normal, self->dmg, 1, DAMAGE_ENERGY, mod);
+				normal, self->dmg, 1, DAMAGE_ENERGY, mod);
 	}
 	else
 	{
 		gi.WriteByte(svc_temp_entity);
 		gi.WriteByte(TE_BLASTER);
 		gi.WritePosition(self->s.origin);
-
-		if (!plane)
-		{
-			gi.WriteDir(vec3_origin);
-		}
-		else
-		{
-			gi.WriteDir(plane->normal);
-		}
-
+		gi.WriteDir(normal);
 		gi.multicast(self->s.origin, MULTICAST_PVS);
 	}
 
@@ -763,6 +770,7 @@ void
 rocket_touch(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 {
 	vec3_t origin;
+	vec3_t normal;
 	int n;
 
 	if (!ent || !other)
@@ -792,8 +800,10 @@ rocket_touch(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 
 	if (other->takedamage)
 	{
+		get_normal_vector(plane, normal);
+
 		T_Damage(other, ent, ent->owner, ent->velocity, ent->s.origin,
-				plane->normal, ent->dmg, 0, 0, MOD_ROCKET);
+				normal, ent->dmg, 0, 0, MOD_ROCKET);
 	}
 	else
 	{
@@ -1026,6 +1036,8 @@ bfg_explode(edict_t *self)
 void
 bfg_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
 {
+	vec3_t normal;
+
 	if (!self || !other)
 	{
 		G_FreeEdict(self);
@@ -1051,8 +1063,10 @@ bfg_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
 	/* core explosion - prevents firing it into the wall/floor */
 	if (other->takedamage)
 	{
+		get_normal_vector(plane, normal);
+
 		T_Damage(other, self, self->owner, self->velocity, self->s.origin,
-				plane->normal, 200, 0, 0, MOD_BFG_BLAST);
+				normal, 200, 0, 0, MOD_BFG_BLAST);
 	}
 
 	T_RadiusDamage(self, self->owner, 200, other, 100, MOD_BFG_BLAST);
@@ -1248,7 +1262,9 @@ ionripper_sparks(edict_t *self)
 void
 ionripper_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
 {
-	if (!self || !other || !plane)
+	vec3_t normal;
+
+	if (!self || !other)
 	{
 		return;
 	}
@@ -1271,8 +1287,10 @@ ionripper_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf
 
 	if (other->takedamage)
 	{
+		get_normal_vector(plane, normal);
+
 		T_Damage(other, self, self->owner, self->velocity, self->s.origin,
-				plane->normal, self->dmg, 1, DAMAGE_ENERGY, MOD_RIPPER);
+				normal, self->dmg, 1, DAMAGE_ENERGY, MOD_RIPPER);
 
 		G_FreeEdict(self);
 	}
@@ -1440,8 +1458,9 @@ void
 plasma_touch(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 {
 	vec3_t origin;
+	vec3_t normal;
 
-	if (!ent || !other || !plane)
+	if (!ent || !other)
 	{
 		return;
 	}
@@ -1467,8 +1486,10 @@ plasma_touch(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 
 	if (other->takedamage)
 	{
+		get_normal_vector(plane, normal);
+
 		T_Damage(other, ent, ent->owner, ent->velocity, ent->s.origin,
-				plane->normal, ent->dmg, 0, 0, MOD_PHALANX);
+				normal, ent->dmg, 0, 0, MOD_PHALANX);
 	}
 
 	T_RadiusDamage(ent, ent->owner, ent->radius_dmg, other,

--- a/src/g_weapon.c
+++ b/src/g_weapon.c
@@ -9,19 +9,6 @@
 
 extern void SP_item_foodcube(edict_t *best);
 
-static void
-get_normal_vector(const cplane_t *p, vec3_t normal)
-{
-	if (p)
-	{
-		VectorCopy(p->normal, normal);
-	}
-	else
-	{
-		VectorCopy(vec3_origin, normal);
-	}
-}
-
 /*
  * This is a support routine used when a client is firing
  * a non-instant attack weapon.  It checks to see if a

--- a/src/g_weapon.c
+++ b/src/g_weapon.c
@@ -859,7 +859,7 @@ fire_rocket(edict_t *self, vec3_t start, vec3_t dir, int damage,
 	rocket->s.modelindex = gi.modelindex("models/objects/rocket/tris.md2");
 	rocket->owner = self;
 	rocket->touch = rocket_touch;
-	rocket->nextthink = level.time + 8000 / speed;
+	rocket->nextthink = level.time + (8000.0f / (float)speed);
 	rocket->think = G_FreeEdict;
 	rocket->dmg = damage;
 	rocket->radius_dmg = radius_damage;
@@ -1206,7 +1206,7 @@ fire_bfg(edict_t *self, vec3_t start, vec3_t dir, int damage,
 	bfg->s.modelindex = gi.modelindex("sprites/s_bfg1.sp2");
 	bfg->owner = self;
 	bfg->touch = bfg_touch;
-	bfg->nextthink = level.time + 8000 / speed;
+	bfg->nextthink = level.time + (8000.0f / (float)speed);
 	bfg->think = G_FreeEdict;
 	bfg->radius_dmg = damage;
 	bfg->dmg_radius = damage_radius;
@@ -1248,7 +1248,7 @@ ionripper_sparks(edict_t *self)
 void
 ionripper_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
 {
-	if (!self || !other || !plane || !surf)
+	if (!self || !other || !plane)
 	{
 		return;
 	}
@@ -1273,13 +1273,9 @@ ionripper_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf
 	{
 		T_Damage(other, self, self->owner, self->velocity, self->s.origin,
 				plane->normal, self->dmg, 1, DAMAGE_ENERGY, MOD_RIPPER);
-	}
-	else
-	{
-		return;
-	}
 
-	G_FreeEdict(self);
+		G_FreeEdict(self);
+	}
 }
 
 void
@@ -1445,7 +1441,7 @@ plasma_touch(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 {
 	vec3_t origin;
 
-	if (!ent || !other || !plane || !surf)
+	if (!ent || !other || !plane)
 	{
 		return;
 	}
@@ -1511,7 +1507,7 @@ fire_plasma(edict_t *self, vec3_t start, vec3_t dir, int damage,
 
 	plasma->owner = self;
 	plasma->touch = plasma_touch;
-	plasma->nextthink = level.time + 8000 / speed;
+	plasma->nextthink = level.time + (8000.0f / (float)speed);
 	plasma->think = G_FreeEdict;
 	plasma->dmg = damage;
 	plasma->radius_dmg = radius_damage;

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -641,7 +641,6 @@ void T_RadiusDamage(edict_t *inflictor, edict_t *attacker, float damage,
 #define DEFAULT_BULLET_VSPREAD 500
 #define DEFAULT_SHOTGUN_HSPREAD 1000
 #define DEFAULT_SHOTGUN_VSPREAD 500
-#define DEFAULT_DEATHMATCH_SHOTGUN_COUNT 12
 #define DEFAULT_SHOTGUN_COUNT 12
 #define DEFAULT_SSHOTGUN_COUNT 20
 

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -616,6 +616,7 @@ char *G_CopyString(char *in);
 
 float *tv(float x, float y, float z);
 char *vtos(vec3_t v);
+void get_normal_vector(const cplane_t *p, vec3_t normal);
 
 float vectoyaw(vec3_t vec);
 void vectoangles(vec3_t vec, vec3_t angles);

--- a/src/monster/boss2/boss2.c
+++ b/src/monster/boss2/boss2.c
@@ -713,10 +713,6 @@ Boss2_CheckAttack(edict_t *self)
 	{
 		chance = 0.4;
 	}
-	else if (enemy_range == RANGE_MELEE)
-	{
-		chance = 0.8;
-	}
 	else if (enemy_range == RANGE_NEAR)
 	{
 		chance = 0.8;

--- a/src/monster/boss3/boss31.c
+++ b/src/monster/boss3/boss31.c
@@ -810,10 +810,6 @@ Jorg_CheckAttack(edict_t *self)
 	{
 		chance = 0.4;
 	}
-	else if (enemy_range == RANGE_MELEE)
-	{
-		chance = 0.8;
-	}
 	else if (enemy_range == RANGE_NEAR)
 	{
 		chance = 0.4;

--- a/src/monster/boss3/boss32.c
+++ b/src/monster/boss3/boss32.c
@@ -986,10 +986,6 @@ Makron_CheckAttack(edict_t *self)
 	{
 		chance = 0.4;
 	}
-	else if (enemy_range == RANGE_MELEE)
-	{
-		chance = 0.8;
-	}
 	else if (enemy_range == RANGE_NEAR)
 	{
 		chance = 0.4;

--- a/src/monster/fixbot/fixbot.c
+++ b/src/monster/fixbot/fixbot.c
@@ -265,7 +265,6 @@ change_to_roam(edict_t *self)
 	{
 		landing_goal(self);
 		self->monsterinfo.currentmove = &fixbot_move_landing;
-		self->spawnflags &= ~16;
 		self->spawnflags = 32;
 	}
 
@@ -273,14 +272,12 @@ change_to_roam(edict_t *self)
 	{
 		takeoff_goal(self);
 		self->monsterinfo.currentmove = &fixbot_move_takeoff;
-		self->spawnflags &= ~8;
 		self->spawnflags = 32;
 	}
 
 	if (self->spawnflags & 4)
 	{
 		self->monsterinfo.currentmove = &fixbot_move_roamgoal;
-		self->spawnflags &= ~4;
 		self->spawnflags = 32;
 	}
 

--- a/src/monster/gekk/gekk.c
+++ b/src/monster/gekk/gekk.c
@@ -56,7 +56,7 @@ gekk_check_melee(edict_t *self)
 		return false;
 	}
 
-	if (!self->enemy && (self->enemy->health <= 0))
+	if (!self->enemy || (self->enemy->health <= 0))
 	{
 		return false;
 	}
@@ -761,7 +761,7 @@ gekk_check_refire(edict_t *self)
 void
 loogie_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
 {
-  	if (!self || !other || !plane || !surf)
+  	if (!self || !other || !plane)
 	{
 		return;
 	}

--- a/src/monster/gekk/gekk.c
+++ b/src/monster/gekk/gekk.c
@@ -761,7 +761,9 @@ gekk_check_refire(edict_t *self)
 void
 loogie_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
 {
-  	if (!self || !other || !plane)
+	vec3_t normal;
+
+  	if (!self || !other)
 	{
 		return;
 	}
@@ -784,8 +786,10 @@ loogie_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
 
 	if (other->takedamage)
 	{
+		get_normal_vector(plane, normal);
+
 		T_Damage(other, self, self->owner, self->velocity, self->s.origin,
-				plane->normal, self->dmg, 1, DAMAGE_ENERGY,
+				normal, self->dmg, 1, DAMAGE_ENERGY,
 				MOD_GEKK);
 	}
 

--- a/src/monster/misc/move.c
+++ b/src/monster/misc/move.c
@@ -10,8 +10,6 @@
 #define DI_NODIR -1
 #define STEPSIZE 18
 
-int c_yes, c_no;
-
 /*
  * Returns false if any part of the bottom
  * of the entity is off an edge that is not
@@ -52,12 +50,9 @@ M_CheckBottom(edict_t *ent)
 		}
 	}
 
-	c_yes++;
 	return true; /* we got out easy */
 
 realcheck:
-	c_no++;
-
 	/* check it for real... */
 	start[2] = mins[2];
 
@@ -98,7 +93,6 @@ realcheck:
 		}
 	}
 
-	c_yes++;
 	return true;
 }
 
@@ -513,11 +507,6 @@ SV_NewChaseDir(edict_t *actor, edict_t *enemy, float dist)
 	float tdir, olddir, turnaround;
 
 	if (!actor || !enemy)
-	{
-		return;
-	}
-
-	if (!enemy)
 	{
 		return;
 	}

--- a/src/player/client.c
+++ b/src/player/client.c
@@ -554,7 +554,7 @@ LookAtKiller(edict_t *self, edict_t *inflictor, edict_t *attacker)
 {
 	vec3_t dir;
 
-	if (!self || !inflictor || !attacker)
+	if (!self)
 	{
 		return;
 	}

--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -1605,16 +1605,8 @@ weapon_shotgun_fire(edict_t *ent)
 		kick *= 4;
 	}
 
-	if (deathmatch->value)
-	{
-		fire_shotgun(ent, start, forward, damage, kick, 500, 500,
-				DEFAULT_DEATHMATCH_SHOTGUN_COUNT, MOD_SHOTGUN);
-	}
-	else
-	{
-		fire_shotgun(ent, start, forward, damage, kick, 500,
-				500, DEFAULT_SHOTGUN_COUNT, MOD_SHOTGUN);
-	}
+	fire_shotgun(ent, start, forward, damage, kick, 500,
+			500, DEFAULT_SHOTGUN_COUNT, MOD_SHOTGUN);
 
 	/* send muzzle flash */
 	gi.WriteByte(svc_muzzleflash);

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -57,7 +57,7 @@ RotatePointAroundVector(vec3_t dst, const vec3_t dir,
 	im[2][1] = m[1][2];
 
 	memset(zrot, 0, sizeof(zrot));
-	zrot[0][0] = zrot[1][1] = zrot[2][2] = 1.0F;
+	zrot[1][1] = zrot[2][2] = 1.0F;
 
 	zrot[0][0] = (float)cos(DEG2RAD(degrees));
 	zrot[0][1] = (float)sin(DEG2RAD(degrees));
@@ -851,6 +851,7 @@ Swap_Init(void)
 	byte swaptest[2] = {1, 0};
 
 	/* set the byte swapping variables in a portable manner */
+	/* PVS NOTE: maybe use memcpy here? */
 	if (*(short *)swaptest == 1)
 	{
 		bigendien = false;
@@ -1072,7 +1073,7 @@ Com_sprintf(char *dest, int size, char *fmt, ...)
 	len = vsnprintf(bigbuffer, 0x10000, fmt, argptr);
 	va_end(argptr);
 
-	if ((len >= size) || (len == size))
+	if (len >= size)
 	{
 		Com_Printf("Com_sprintf: overflow\n");
 
@@ -1325,7 +1326,7 @@ Info_SetValueForKey(char *s, char *key, char *value)
 
 	Info_RemoveKey(s, key);
 
-	if (!value || !strlen(value))
+	if (*value == '\0')
 	{
 		return;
 	}


### PR DESCRIPTION
This pull request fixes (almost) all of the issues reported in bug https://github.com/yquake2/xatrix/issues/17.

The exceptions are:
1. The type-punning stuff in g_svcmds and shared I did not mess with. Instead I added a comment for future reference, suggesting using memcpy which is, as far as I know, the correct way to do type-punning with compiler optimizations enabled.

2. The PVS analysis does not know that gi.error() doesn't return so it falsely reported a number of issues in savegame.c. Perhaps gi.error() should be decorated with _Noreturn (one of the newer features of the C standard)?

3. Short global var names in rand.c. They are declared static and are in a file not likely to change in the future so I don't see this as an issue. But feel free to give them longer names if you want.

The rest of the issues I did address were a variety of dead code elimination, expression and block simplification, some possible null pointer refs, incorrect use of rand() instead of random(), etc. Overall not many outright bugs were fixed but there were a few in there.