### PR TITLE
Fix monsters being disoriented after ducking

### DIFF
--- a/src/monster/brain/brain.c
+++ b/src/monster/brain/brain.c
@@ -363,6 +363,7 @@ brain_dodge(edict_t *self, edict_t *attacker, float eta)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	self->monsterinfo.pausetime = level.time + eta + 0.5;

--- a/src/monster/chick/chick.c
+++ b/src/monster/chick/chick.c
@@ -589,6 +589,7 @@ chick_dodge(edict_t *self, edict_t *attacker, float eta)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	self->monsterinfo.currentmove = &chick_move_duck;

--- a/src/monster/gekk/gekk.c
+++ b/src/monster/gekk/gekk.c
@@ -1793,6 +1793,7 @@ gekk_dodge(edict_t *self, edict_t *attacker, float eta)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	if (self->waterlevel)

--- a/src/monster/gunner/gunner.c
+++ b/src/monster/gunner/gunner.c
@@ -574,6 +574,7 @@ gunner_dodge(edict_t *self, edict_t *attacker, float eta /* unsued */)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	self->monsterinfo.currentmove = &gunner_move_duck;

--- a/src/monster/infantry/infantry.c
+++ b/src/monster/infantry/infantry.c
@@ -608,6 +608,7 @@ infantry_dodge(edict_t *self, edict_t *attacker, float eta /* unused */)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	self->monsterinfo.currentmove = &infantry_move_duck;

--- a/src/monster/medic/medic.c
+++ b/src/monster/medic/medic.c
@@ -666,6 +666,7 @@ medic_dodge(edict_t *self, edict_t *attacker, float eta /* unused */)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	self->monsterinfo.currentmove = &medic_move_duck;

--- a/src/monster/soldier/soldier.c
+++ b/src/monster/soldier/soldier.c
@@ -1047,6 +1047,7 @@ soldier_dodge(edict_t *self, edict_t *attacker, float eta)
 	if (!self->enemy)
 	{
 		self->enemy = attacker;
+		FoundTarget(self);
 	}
 
 	if (skill->value == 0)


### PR DESCRIPTION
Xatrix fix for bug https://github.com/yquake2/yquake2/issues/456. Rogue fix is not necessary because rogue overhauled the dodging code, including adding the missing FoundTarget()s.