### PR TITLE
Quad sound for quadded hand grenades

### DIFF
--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -744,6 +744,9 @@ weapon_grenade_fire(edict_t *ent, qboolean held)
 	if (is_quad)
 	{
 		damage *= 4;
+
+		gi.sound(ent, CHAN_ITEM, gi.soundindex(
+				"items/damage3.wav"), 1, ATTN_NORM, 0);
 	}
 
 	VectorSet(offset, 8, 8, ent->viewheight - 8);


### PR DESCRIPTION
This pull request addresses the inconsistency reported in https://github.com/yquake2/yquake2/issues/470.

I decided against doing the same for the Trap weapon, because it is not affected by quads, it either gibs the enemy or explodes regardless of quad damage use.