### PR TITLE
Fixed broken xatrix weapon no-ammo switching

### DIFF
--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -298,16 +298,11 @@ NoAmmoWeaponChange(edict_t *ent)
 		return;
 	}
 
-	if (ent->client->pers.inventory[ITEM_INDEX(FindItem("mag slug"))] &&
-		ent->client->pers.inventory[ITEM_INDEX(FindItem("phalanx"))])
-	{
-		ent->client->newweapon = FindItem("phalanx");
-	}
-
-	if (ent->client->pers.inventory[ITEM_INDEX(FindItem("cells"))] &&
+	if (ent->client->pers.inventory[ITEM_INDEX(FindItem("cells"))] > 1 &&
 		ent->client->pers.inventory[ITEM_INDEX(FindItem("ionripper"))])
 	{
-		ent->client->newweapon = FindItem("ionrippergun");
+		ent->client->newweapon = FindItem("ionripper");
+		return;
 	}
 
 	if (ent->client->pers.inventory[ITEM_INDEX(FindItem("cells"))] &&


### PR DESCRIPTION
This PR addresses issue https://github.com/yquake2/xatrix/issues/40, according to option 2 (remove phalanx entry and fix ionripper entry).