### PR TITLE
Small hotfix to make fixbot unstucking logic reachable

### DIFF
--- a/src/monster/fixbot/fixbot.c
+++ b/src/monster/fixbot/fixbot.c
@@ -397,12 +397,10 @@ use_scanner(edict_t *self)
 		if (VectorLength(vec) < 56)
 		{
 			self->monsterinfo.currentmove = &fixbot_move_weld_start;
+			return;
 		}
-
-		return;
 	}
-
-	if (strcmp(self->goalentity->classname, "bot_goal") == 0)
+	else if (strcmp(self->goalentity->classname, "bot_goal") == 0)
 	{
 		VectorSubtract(self->s.origin, self->goalentity->s.origin, vec);
 
@@ -411,10 +409,11 @@ use_scanner(edict_t *self)
 			self->goalentity->nextthink = level.time + 0.1;
 			self->goalentity->think = G_FreeEdict;
 			self->goalentity = self->enemy = NULL;
-			self->monsterinfo.currentmove = &fixbot_move_stand;
-		}
 
-		return;
+			self->monsterinfo.currentmove = &fixbot_move_stand;
+
+			return;
+		}
 	}
 
 	VectorSubtract(self->s.origin, self->s.old_origin, vec);


### PR DESCRIPTION
Sorry about this extra PR @Yamagi but I discovered an error in my new fixbot code - the return statements inside use_scanner() were in the wrong location and made the stuck timeout logic at the bottom of the function unreachable. This version should work as intended and unstuck fixbots that can't reach their goal and don't move.