### PR TITLE
Fix for some items playing wrong sound when instantly activated

### DIFF
--- a/src/g_items.c
+++ b/src/g_items.c
@@ -1272,31 +1272,21 @@ Touch_Item(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 		{
 			if ((((int)dmflags->value & DF_INSTANT_ITEMS) &&
 				 (ent->item->flags & IT_INSTANT_USE)) ||
-				((ent->item->use == Use_Quad) &&
+				(((ent->item->use == Use_Quad) || (ent->item->use == Use_QuadFire)) &&
 				 (ent->spawnflags & DROPPED_PLAYER_ITEM)))
 			{
-				if ((ent->item->use == Use_Quad) &&
-					(ent->spawnflags & DROPPED_PLAYER_ITEM))
+				if (ent->spawnflags & DROPPED_PLAYER_ITEM)
 				{
-					quad_drop_timeout_hack =
-						(ent->nextthink - level.time) / FRAMETIME;
-				}
-
-				if (ent->item->use)
-				{
-					ent->item->use(other, ent->item);
-				}
-			}
-			else if ((((int)dmflags->value & DF_INSTANT_ITEMS) &&
-					  (ent->item->flags & IT_INSTANT_USE)) ||
-					 ((ent->item->use == Use_QuadFire) &&
-					  (ent->spawnflags & DROPPED_PLAYER_ITEM)))
-			{
-				if ((ent->item->use == Use_QuadFire) &&
-					(ent->spawnflags & DROPPED_PLAYER_ITEM))
-				{
-					quad_fire_drop_timeout_hack =
-						(ent->nextthink - level.time) / FRAMETIME;
+					if (ent->item->use == Use_Quad)
+					{
+						quad_drop_timeout_hack =
+							(ent->nextthink - level.time) / FRAMETIME;
+					}
+					else if (ent->item->use == Use_QuadFire)
+					{
+						quad_fire_drop_timeout_hack =
+							(ent->nextthink - level.time) / FRAMETIME;
+					}
 				}
 
 				if (ent->item->use)

--- a/src/g_items.c
+++ b/src/g_items.c
@@ -205,33 +205,6 @@ Pickup_Powerup(edict_t *ent, edict_t *other)
 		{
 			SetRespawn(ent, ent->item->quantity);
 		}
-
-		if (((int)dmflags->value & DF_INSTANT_ITEMS) ||
-			((ent->item->use == Use_Quad) &&
-			 (ent->spawnflags & DROPPED_PLAYER_ITEM)))
-		{
-			if ((ent->item->use == Use_Quad) &&
-				(ent->spawnflags & DROPPED_PLAYER_ITEM))
-			{
-				quad_drop_timeout_hack =
-					(ent->nextthink - level.time) / FRAMETIME;
-			}
-
-			ent->item->use(other, ent->item);
-		}
-		else if (((int)dmflags->value & DF_INSTANT_ITEMS) ||
-				 ((ent->item->use == Use_QuadFire) &&
-				  (ent->spawnflags & DROPPED_PLAYER_ITEM)))
-		{
-			if ((ent->item->use == Use_QuadFire) &&
-				(ent->spawnflags & DROPPED_PLAYER_ITEM))
-			{
-				quad_fire_drop_timeout_hack =
-					(ent->nextthink - level.time) / FRAMETIME;
-			}
-
-			ent->item->use(other, ent->item);
-		}
 	}
 
 	return true;
@@ -1291,6 +1264,46 @@ Touch_Item(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 		{
 			gi.sound(other, CHAN_ITEM, gi.soundindex(
 							ent->item->pickup_sound), 1, ATTN_NORM, 0);
+		}
+
+		/* activate item instantly if appropriate */
+		/* moved down here so activation sounds override the pickup sound */
+		if (deathmatch->value)
+		{
+			if ((((int)dmflags->value & DF_INSTANT_ITEMS) &&
+				 (ent->item->flags & IT_INSTANT_USE)) ||
+				((ent->item->use == Use_Quad) &&
+				 (ent->spawnflags & DROPPED_PLAYER_ITEM)))
+			{
+				if ((ent->item->use == Use_Quad) &&
+					(ent->spawnflags & DROPPED_PLAYER_ITEM))
+				{
+					quad_drop_timeout_hack =
+						(ent->nextthink - level.time) / FRAMETIME;
+				}
+
+				if (ent->item->use)
+				{
+					ent->item->use(other, ent->item);
+				}
+			}
+			else if ((((int)dmflags->value & DF_INSTANT_ITEMS) &&
+					  (ent->item->flags & IT_INSTANT_USE)) ||
+					 ((ent->item->use == Use_QuadFire) &&
+					  (ent->spawnflags & DROPPED_PLAYER_ITEM)))
+			{
+				if ((ent->item->use == Use_QuadFire) &&
+					(ent->spawnflags & DROPPED_PLAYER_ITEM))
+				{
+					quad_fire_drop_timeout_hack =
+						(ent->nextthink - level.time) / FRAMETIME;
+				}
+
+				if (ent->item->use)
+				{
+					ent->item->use(other, ent->item);
+				}
+			}
 		}
 	}
 
@@ -2393,7 +2406,7 @@ gitem_t itemlist[] = {
 		2,
 		60,
 		NULL,
-		IT_POWERUP,
+		IT_POWERUP | IT_INSTANT_USE,
 		0,
 		NULL,
 		0,
@@ -2418,7 +2431,7 @@ gitem_t itemlist[] = {
 		2,
 		60,
 		NULL,
-		IT_POWERUP,
+		IT_POWERUP | IT_INSTANT_USE,
 		0,
 		NULL,
 		0,
@@ -2442,7 +2455,7 @@ gitem_t itemlist[] = {
 		2,
 		300,
 		NULL,
-		IT_POWERUP,
+		IT_POWERUP | IT_INSTANT_USE,
 		0,
 		NULL,
 		0,
@@ -2466,7 +2479,7 @@ gitem_t itemlist[] = {
 		2,
 		60,
 		NULL,
-		IT_POWERUP,
+		IT_POWERUP | IT_INSTANT_USE,
 		0,
 		NULL,
 		0,
@@ -2490,7 +2503,7 @@ gitem_t itemlist[] = {
 		2,
 		60,
 		NULL,
-		IT_STAY_COOP | IT_POWERUP,
+		IT_STAY_COOP | IT_POWERUP | IT_INSTANT_USE,
 		0,
 		NULL,
 		0,
@@ -2514,7 +2527,7 @@ gitem_t itemlist[] = {
 		2,
 		60,
 		NULL,
-		IT_STAY_COOP | IT_POWERUP,
+		IT_STAY_COOP | IT_POWERUP | IT_INSTANT_USE,
 		0,
 		NULL,
 		0,

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -202,6 +202,7 @@ typedef struct
 #define IT_STAY_COOP 8
 #define IT_KEY 16
 #define IT_POWERUP 32
+#define IT_INSTANT_USE 64 /* item is insta-used on pickup if dmflag is set */
 
 /* gitem_t->weapmodel for weapons indicates model index */
 #define WEAP_BLASTER 1


### PR DESCRIPTION
Xatrix fix for bug https://github.com/yquake2/yquake2/issues/547.

This also fixes an original xatrix bug I discovered while moving the instant use code. If you have both DF_INSTANT_ITEMS and DF_QUADFIRE_DROP set (dmflags 65552), then the quadfire drop timer is not applied and you get a full 30 second powerup no matter how little lifetime it has left. The fix makes it work as intended - the same way as dropped quads work.