### PR TITLE
Feature request : add cvar to disable machine gun recoil in single player #741 (xatrix)

### DIFF
--- a/src/g_main.c
+++ b/src/g_main.c
@@ -67,6 +67,7 @@ cvar_t *sv_maplist;
 cvar_t *gib_on;
 
 cvar_t *aimfix;
+cvar_t *machinegun_norecoil;
 
 void SpawnEntities(char *mapname, char *entities, char *spawnpoint);
 void ClientThink(edict_t *ent, usercmd_t *cmd);

--- a/src/g_main.c
+++ b/src/g_main.c
@@ -67,7 +67,7 @@ cvar_t *sv_maplist;
 cvar_t *gib_on;
 
 cvar_t *aimfix;
-cvar_t *machinegun_norecoil;
+cvar_t *g_machinegun_norecoil;
 
 void SpawnEntities(char *mapname, char *entities, char *spawnpoint);
 void ClientThink(edict_t *ent, usercmd_t *cmd);

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -541,7 +541,7 @@ extern cvar_t *flood_waitdelay;
 extern cvar_t *sv_maplist;
 
 extern cvar_t *aimfix;
-extern cvar_t *machinegun_norecoil;
+extern cvar_t *g_machinegun_norecoil;
 
 #define world (&g_edicts[0])
 

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -541,6 +541,7 @@ extern cvar_t *flood_waitdelay;
 extern cvar_t *sv_maplist;
 
 extern cvar_t *aimfix;
+extern cvar_t *machinegun_norecoil;
 
 #define world (&g_edicts[0])
 

--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -1345,7 +1345,7 @@ Machinegun_Fire(edict_t *ent)
 	ent->client->kick_angles[0] = ent->client->machinegun_shots * -1.5;
 
 	/* raise the gun as it is firing */
-	if (!(deathmatch->value || machinegun_norecoil->value))
+	if (!(deathmatch->value || g_machinegun_norecoil->value))
 	{
 		ent->client->machinegun_shots++;
 

--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -1345,7 +1345,7 @@ Machinegun_Fire(edict_t *ent)
 	ent->client->kick_angles[0] = ent->client->machinegun_shots * -1.5;
 
 	/* raise the gun as it is firing */
-	if (!deathmatch->value)
+	if (!(deathmatch->value || machinegun_norecoil->value))
 	{
 		ent->client->machinegun_shots++;
 

--- a/src/savegame/savegame.c
+++ b/src/savegame/savegame.c
@@ -250,6 +250,7 @@ InitGame(void)
 
 	/* others */
 	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
+	machinegun_norecoil = gi.cvar("machinegun_norecoil", "0", CVAR_ARCHIVE);
 
 	/* items */
 	InitItems ();

--- a/src/savegame/savegame.c
+++ b/src/savegame/savegame.c
@@ -250,7 +250,7 @@ InitGame(void)
 
 	/* others */
 	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
-	machinegun_norecoil = gi.cvar("machinegun_norecoil", "0", CVAR_ARCHIVE);
+	g_machinegun_norecoil = gi.cvar("g_machinegun_norecoil", "0", CVAR_ARCHIVE);
 
 	/* items */
 	InitItems ();


### PR DESCRIPTION
This adds the cvar machinegun_norecoil
It should only impact non-deathmatch games.
I used the aimfix cvar as a template to make this change.

The cvar will only work if the game.dll supports it.