### PR TITLE
Underwater impacts of the Phalanx cannon sound muffled

### DIFF
--- a/src/g_weapon.c
+++ b/src/g_weapon.c
@@ -1483,7 +1483,16 @@ plasma_touch(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 			ent->dmg_radius, MOD_PHALANX);
 
 	gi.WriteByte(svc_temp_entity);
-	gi.WriteByte(TE_PLASMA_EXPLOSION);
+
+	if (ent->waterlevel)
+	{
+		gi.WriteByte(TE_ROCKET_EXPLOSION_WATER);
+	}
+	else
+	{
+		gi.WriteByte(TE_PLASMA_EXPLOSION);
+	}
+
 	gi.WritePosition(origin);
 	gi.multicast(ent->s.origin, MULTICAST_PVS);
 


### PR DESCRIPTION
Explosions for rockets and grenades, when underwater, have an appropiate muffled sound. Strangely, this doesn't apply to the Phalanx shots that impact underwater; they sound the same as if they're on the ground. You can test this by starting the Xatrix campaign, where you begin in a small lagoon, and cheat to give yourself all weapons; you can test how rockets and grenades sound over and under water, and then do the same with the Phalanx cannon.

This PR addresses this, giving those explosions the same muffled sound of the rockets and grenades. Code was copied from `rocket_touch()` and `Grenade_Explode()` functions, in the same `g_weapon.c`.
Also, if you check the `CL_ParseTEnt()` function inside `src/client/cl_tempentities.c` of the yquake2 project, you'll see that behaviour between `TE_PLASMA_EXPLOSION` and `TE_ROCKET_EXPLOSION` is so alike that the duplication looks like a waste. So, seeing that even the grenades use the rocket underwater explosion, I applied the same to the plasma explosion.