### PR TITLE
Update weapon.c

### DIFF
--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -1785,8 +1785,21 @@ weapon_supershotgun_fire(edict_t *ent)
 	v[YAW] = ent->client->v_angle[YAW] - 5;
 	v[ROLL] = ent->client->v_angle[ROLL];
 	AngleVectors(v, forward, NULL, NULL);
+	
+	if (aimfix->value)
+	{	
+		AngleVectors(v, forward, right, NULL);
+
+		VectorScale(forward, -2, ent->client->kick_origin);
+		ent->client->kick_angles[0] = -2;
+
+		VectorSet(offset, 0, 8, ent->viewheight - 8);
+		P_ProjectSource(ent, offset, forward, right, start);
+	}	
+	
 	fire_shotgun(ent, start, forward, damage, kick, DEFAULT_SHOTGUN_HSPREAD,
 			DEFAULT_SHOTGUN_VSPREAD, DEFAULT_SSHOTGUN_COUNT / 2, MOD_SSHOTGUN);
+	
 	v[YAW] = ent->client->v_angle[YAW] + 5;
 	AngleVectors(v, forward, NULL, NULL);
 	


### PR DESCRIPTION
the aimfix was working only on half of the attack, since the supershotgun shoots 2 times (half bullets left, half bullets right)

to carefully test it i tried to comment out 1 of the 2 shots while also keep yaw change to 0 in 1 case the bullets hit around the crossair, in the other case the bullets were not centered around the crossair.

i added the same fix to the shot that did not have it, and it worked.

i tested it out with yaw-5 and yaw+5 with both shots shooting at the same time and the bullets appeared to gather into 2 distinct clusters one left side of crossair, one right side of crossair like 2 eyes on the wall