### PR TITLE
Update weapon.c

### DIFF
--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -2159,6 +2159,17 @@ weapon_phalanx_fire(edict_t *ent)
 		v[ROLL] = ent->client->v_angle[ROLL];
 		AngleVectors(v, forward, right, up);
 
+		if (aimfix->value)
+		{
+			AngleVectors(v, forward, right, NULL);
+
+			VectorScale(forward, -2, ent->client->kick_origin);
+			ent->client->kick_angles[0] = -2;
+
+			VectorSet(offset, 0, 8, ent->viewheight - 8);
+			P_ProjectSource(ent, offset, forward, right, start);
+		}
+		
 		radius_damage = 30;
 		damage_radius = 120;
 
@@ -2176,6 +2187,18 @@ weapon_phalanx_fire(edict_t *ent)
 		v[YAW] = ent->client->v_angle[YAW] + 1.5;
 		v[ROLL] = ent->client->v_angle[ROLL];
 		AngleVectors(v, forward, right, up);
+		
+		if (aimfix->value)
+		{
+			AngleVectors(v, forward, right, NULL);
+
+			VectorScale(forward, -2, ent->client->kick_origin);
+			ent->client->kick_angles[0] = -2;
+
+			VectorSet(offset, 0, 8, ent->viewheight - 8);
+			P_ProjectSource(ent, offset, forward, right, start);
+		}
+		
 		fire_plasma(ent, start, forward, damage, 725,
 				damage_radius, radius_damage);
 


### PR DESCRIPTION
phalanx aimfix (like the supershotgun)
the first shot (in the if statement) is to the right, the second shot (in the else statement) shoots left

without the change to the code 1 shot is centered on the aim cross, the other is on the right.
with the change to the code the left shot is on the left of the crossair and it touches the left -- of the crossair, while the right shot is on the right and touches the right -- of the crossair