### PR TITLE
Cheat to speed up "weapon change" animations

### DIFF
--- a/src/g_main.c
+++ b/src/g_main.c
@@ -68,6 +68,7 @@ cvar_t *gib_on;
 
 cvar_t *aimfix;
 cvar_t *g_machinegun_norecoil;
+cvar_t *g_swap_speed;
 
 void SpawnEntities(char *mapname, char *entities, char *spawnpoint);
 void ClientThink(edict_t *ent, usercmd_t *cmd);

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -542,6 +542,7 @@ extern cvar_t *sv_maplist;
 
 extern cvar_t *aimfix;
 extern cvar_t *g_machinegun_norecoil;
+extern cvar_t *g_swap_speed;
 
 #define world (&g_edicts[0])
 

--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -699,7 +699,7 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST,
 
 	if (ent->client->weaponstate == WEAPON_DROPPING)
 	{
-		if (ent->client->ps.gunframe == FRAME_DEACTIVATE_LAST)
+		if (ent->client->ps.gunframe >= FRAME_DEACTIVATE_LAST - change_speed + 1)
 		{
 			ChangeWeapon(ent);
 			return;
@@ -716,16 +716,12 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST,
 		}
 
 		ent->client->ps.gunframe += change_speed;
-		if (ent->client->ps.gunframe > FRAME_DEACTIVATE_LAST)
-		{
-			ent->client->ps.gunframe = FRAME_DEACTIVATE_LAST;
-		}
 		return;
 	}
 
 	if (ent->client->weaponstate == WEAPON_ACTIVATING)
 	{
-		if (ent->client->ps.gunframe == FRAME_ACTIVATE_LAST)
+		if (ent->client->ps.gunframe >= FRAME_ACTIVATE_LAST - change_speed + 1)
 		{
 			ent->client->weaponstate = WEAPON_READY;
 			ent->client->ps.gunframe = FRAME_IDLE_FIRST;
@@ -733,10 +729,6 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST,
 		}
 
 		ent->client->ps.gunframe += change_speed;
-		if (ent->client->ps.gunframe > FRAME_ACTIVATE_LAST)
-		{
-			ent->client->ps.gunframe = FRAME_ACTIVATE_LAST;
-		}
 		return;
 	}
 

--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -494,6 +494,31 @@ Think_Weapon(edict_t *ent)
 }
 
 /*
+ * Client (player) animation for changing weapon
+ */
+static void
+Change_Weap_Animation(edict_t *ent)
+{
+	if (!ent)
+	{
+		return;
+	}
+
+	ent->client->anim_priority = ANIM_REVERSE;
+
+	if (ent->client->ps.pmove.pm_flags & PMF_DUCKED)
+	{
+		ent->s.frame = FRAME_crpain4 + 1;
+		ent->client->anim_end = FRAME_crpain1;
+	}
+	else
+	{
+		ent->s.frame = FRAME_pain304 + 1;
+		ent->client->anim_end = FRAME_pain301;
+	}
+}
+
+/*
  * Make the weapon ready if there is ammo
  */
 void
@@ -660,6 +685,7 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST,
 		int *fire_frames, void (*fire)(edict_t *ent))
 {
 	int n;
+	const unsigned short int change_speed = (g_swap_speed->value > 0)?(unsigned short int)g_swap_speed->value:1;
 
 	if (!ent || !fire_frames || !fire)
 	{
@@ -678,23 +704,22 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST,
 			ChangeWeapon(ent);
 			return;
 		}
-		else if ((FRAME_DEACTIVATE_LAST - ent->client->ps.gunframe) == 4)
+		else if ( (FRAME_DEACTIVATE_LAST - FRAME_DEACTIVATE_FIRST) >= (4 * change_speed) )
 		{
-			ent->client->anim_priority = ANIM_REVERSE;
-
-			if (ent->client->ps.pmove.pm_flags & PMF_DUCKED)
+			unsigned short int remainder = FRAME_DEACTIVATE_LAST - ent->client->ps.gunframe;
+			// "if (remainder == 4)" at change_speed == 1
+			if ( ( remainder <= (4 * change_speed) )
+				&& ( remainder > (3 * change_speed) ) )
 			{
-				ent->s.frame = FRAME_crpain4 + 1;
-				ent->client->anim_end = FRAME_crpain1;
-			}
-			else
-			{
-				ent->s.frame = FRAME_pain304 + 1;
-				ent->client->anim_end = FRAME_pain301;
+				Change_Weap_Animation(ent);
 			}
 		}
 
-		ent->client->ps.gunframe++;
+		ent->client->ps.gunframe += change_speed;
+		if (ent->client->ps.gunframe > FRAME_DEACTIVATE_LAST)
+		{
+			ent->client->ps.gunframe = FRAME_DEACTIVATE_LAST;
+		}
 		return;
 	}
 
@@ -707,7 +732,11 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST,
 			return;
 		}
 
-		ent->client->ps.gunframe++;
+		ent->client->ps.gunframe += change_speed;
+		if (ent->client->ps.gunframe > FRAME_ACTIVATE_LAST)
+		{
+			ent->client->ps.gunframe = FRAME_ACTIVATE_LAST;
+		}
 		return;
 	}
 
@@ -716,20 +745,9 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST,
 		ent->client->weaponstate = WEAPON_DROPPING;
 		ent->client->ps.gunframe = FRAME_DEACTIVATE_FIRST;
 
-		if ((FRAME_DEACTIVATE_LAST - FRAME_DEACTIVATE_FIRST) < 4)
+		if ( (FRAME_DEACTIVATE_LAST - FRAME_DEACTIVATE_FIRST) < (4 * change_speed) )
 		{
-			ent->client->anim_priority = ANIM_REVERSE;
-
-			if (ent->client->ps.pmove.pm_flags & PMF_DUCKED)
-			{
-				ent->s.frame = FRAME_crpain4 + 1;
-				ent->client->anim_end = FRAME_crpain1;
-			}
-			else
-			{
-				ent->s.frame = FRAME_pain304 + 1;
-				ent->client->anim_end = FRAME_pain301;
-			}
+			Change_Weap_Animation(ent);
 		}
 
 		return;

--- a/src/savegame/savegame.c
+++ b/src/savegame/savegame.c
@@ -251,6 +251,7 @@ InitGame(void)
 	/* others */
 	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
 	g_machinegun_norecoil = gi.cvar("g_machinegun_norecoil", "0", CVAR_ARCHIVE);
+	g_swap_speed = gi.cvar("g_swap_speed", "1", 0);
 
 	/* items */
 	InitItems ();


### PR DESCRIPTION
Xatrix version of https://github.com/yquake2/yquake2/pull/1031
Allows to skip frames of "putting down weapon" and "raising weapon" animations, speeding them up.