### PR TITLE
Faster "weapprev" and "weapnext" behavior

### DIFF
--- a/src/g_cmds.c
+++ b/src/g_cmds.c
@@ -759,14 +759,22 @@ Cmd_WeapPrev_f(edict_t *ent)
 
 	cl = ent->client;
 
-	if (!cl->pers.weapon)
+	if (g_quick_weap->value && cl->newweapon)
+	{
+		it = cl->newweapon;
+	}
+	else if (cl->pers.weapon)
+	{
+		it = cl->pers.weapon;
+	}
+	else
 	{
 		return;
 	}
 
-	selected_weapon = ITEM_INDEX(cl->pers.weapon);
+	selected_weapon = ITEM_INDEX(it);
 
-	/* scan  for the next valid one */
+	/* scan for the next valid one */
 	for (i = 1; i <= MAX_ITEMS; i++)
 	{
 		index = (selected_weapon + MAX_ITEMS - i) % MAX_ITEMS;
@@ -778,12 +786,7 @@ Cmd_WeapPrev_f(edict_t *ent)
 
 		it = &itemlist[index];
 
-		if (!it->use)
-		{
-			continue;
-		}
-
-		if (!(it->flags & IT_WEAPON))
+		if (!it->use || !(it->flags & IT_WEAPON))
 		{
 			continue;
 		}
@@ -812,14 +815,22 @@ Cmd_WeapNext_f(edict_t *ent)
 
 	cl = ent->client;
 
-	if (!cl->pers.weapon)
+	if (g_quick_weap->value && cl->newweapon)
+	{
+		it = cl->newweapon;
+	}
+	else if (cl->pers.weapon)
+	{
+		it = cl->pers.weapon;
+	}
+	else
 	{
 		return;
 	}
 
-	selected_weapon = ITEM_INDEX(cl->pers.weapon);
+	selected_weapon = ITEM_INDEX(it);
 
-	/* scan  for the next valid one */
+	/* scan for the next valid one */
 	for (i = 1; i <= MAX_ITEMS; i++)
 	{
 		index = (selected_weapon + i) % MAX_ITEMS;
@@ -831,12 +842,7 @@ Cmd_WeapNext_f(edict_t *ent)
 
 		it = &itemlist[index];
 
-		if (!it->use)
-		{
-			continue;
-		}
-
-		if (!(it->flags & IT_WEAPON))
+		if (!it->use || !(it->flags & IT_WEAPON))
 		{
 			continue;
 		}

--- a/src/g_cmds.c
+++ b/src/g_cmds.c
@@ -795,6 +795,12 @@ Cmd_WeapPrev_f(edict_t *ent)
 
 		if (cl->newweapon == it)
 		{
+			if (g_quick_weap->value)
+			{
+				cl->ps.stats[STAT_PICKUP_ICON] = gi.imageindex(cl->newweapon->icon);
+				cl->ps.stats[STAT_PICKUP_STRING] = CS_ITEMS + ITEM_INDEX(cl->newweapon);
+				cl->pickup_msg_time = level.time + 0.9f;
+			}
 			return;
 		}
 	}
@@ -851,6 +857,12 @@ Cmd_WeapNext_f(edict_t *ent)
 
 		if (cl->newweapon == it)
 		{
+			if (g_quick_weap->value)
+			{
+				cl->ps.stats[STAT_PICKUP_ICON] = gi.imageindex(cl->newweapon->icon);
+				cl->ps.stats[STAT_PICKUP_STRING] = CS_ITEMS + ITEM_INDEX(cl->newweapon);
+				cl->pickup_msg_time = level.time + 0.9f;
+			}
 			return;
 		}
 	}

--- a/src/g_main.c
+++ b/src/g_main.c
@@ -68,6 +68,7 @@ cvar_t *gib_on;
 
 cvar_t *aimfix;
 cvar_t *g_machinegun_norecoil;
+cvar_t *g_quick_weap;
 cvar_t *g_swap_speed;
 
 void SpawnEntities(char *mapname, char *entities, char *spawnpoint);

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -542,6 +542,7 @@ extern cvar_t *sv_maplist;
 
 extern cvar_t *aimfix;
 extern cvar_t *g_machinegun_norecoil;
+extern cvar_t *g_quick_weap;
 extern cvar_t *g_swap_speed;
 
 #define world (&g_edicts[0])

--- a/src/savegame/savegame.c
+++ b/src/savegame/savegame.c
@@ -251,6 +251,7 @@ InitGame(void)
 	/* others */
 	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
 	g_machinegun_norecoil = gi.cvar("g_machinegun_norecoil", "0", CVAR_ARCHIVE);
+	g_quick_weap = gi.cvar("g_quick_weap", "0", CVAR_ARCHIVE);
 	g_swap_speed = gi.cvar("g_swap_speed", "1", 0);
 
 	/* items */


### PR DESCRIPTION
Xatrix version of https://github.com/yquake2/yquake2/pull/1076
Allows to skip the "previous" or "next" weapon, by constantly tapping the bound key (or scrolling the mouse wheel).