### PR TITLE
savegame: Remove null entries at end of functionList and mmoveList

### DIFF
--- a/src/savegame/tables/gamefunc_list.h
+++ b/src/savegame/tables/gamefunc_list.h
@@ -1232,4 +1232,3 @@
 {"ai_move", (byte *)ai_move},
 {"AI_SetSightClient", (byte *)AI_SetSightClient},
 {"wait_and_change_think", (byte *)wait_and_change_think},
-{0, 0}

--- a/src/savegame/tables/gamemmove_list.h
+++ b/src/savegame/tables/gamemmove_list.h
@@ -375,4 +375,3 @@
 {"berserk_move_walk", &berserk_move_walk},
 {"berserk_move_stand_fidget", &berserk_move_stand_fidget},
 {"berserk_move_stand", &berserk_move_stand},
-{0, 0}


### PR DESCRIPTION
A small patch for the recent savegame refactor. The null entries at the end of `functionList` and `mmoveList` are no longer needed and would crash the game if the desired entry is not in the list