### PR TITLE
Restore the Phalanx to the out-of-ammo weapon fallback

### DIFF
--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -465,6 +465,13 @@ NoAmmoWeaponChange(edict_t *ent)
 		return;
 	}
 
+	if (ent->client->pers.inventory[ITEM_INDEX(FindItem("mag slug"))] &&
+		ent->client->pers.inventory[ITEM_INDEX(FindItem("phalanx"))])
+	{
+		ent->client->newweapon = FindItem("phalanx");
+		return;
+	}
+
 	ent->client->newweapon = FindItem("blaster");
 }
 


### PR DESCRIPTION
`80b54c4` ("Fixed broken xatrix weapon no-ammo switching", 2019) repaired
`NoAmmoWeaponChange` by fixing the Ionripper branch and deleting the Phalanx
one. Both were broken the same way: Xatrix added them without the `return` that
every other branch in this priority chain has, so the unconditional blaster at
the end discarded whatever they assigned. The Ionripper also looked up
`FindItem("ionrippergun")`, which matches no `pickup_name`.

Deleting the branch fixed the symptom, but it left the Phalanx as the only
Xatrix weapon that can never be chosen when the current one runs dry — a player
holding mag slugs and a Phalanx and nothing else falls back to the blaster. The
2023 remaster treats it as a fallback, listing `IT_WEAPON_PHALANX` in its
`no_ammo_order` table, so this restores the branch with the `return` it should
have had.

It goes back where Xatrix put it, above the Ionripper, which is the only
placement the original source attests. The remaster orders it last instead,
below the shotguns and just above the blaster. **If you would rather this be
purely additive and leave the existing priorities untouched, moving the block to
just before the final blaster line does that — happy to respin it that way.**

Both names resolve: `"Phalanx"` and `"Mag Slug"` are real `pickup_name`s and
`FindItem` compares with `Q_stricmp`.

### Testing

`make` is clean with no new warnings, before and after, on gcc 13 (Linux
aarch64).
